### PR TITLE
Fix missing javascript bundle error

### DIFF
--- a/ios/.xcode.env.local
+++ b/ios/.xcode.env.local
@@ -1,0 +1,1 @@
+export NODE_BINARY=/home/ubuntu/.nvm/versions/node/v22.16.0/bin/node


### PR DESCRIPTION
Add `NODE_BINARY` export to `.xcode.env.local` to ensure Xcode uses the correct Node.js binary for React Native builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-96f6b2dc-56d1-4ce3-ab23-933a6c545036">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96f6b2dc-56d1-4ce3-ab23-933a6c545036">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

